### PR TITLE
Fix typo in project description in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,7 +104,7 @@ We pursue the goal through two dimensions:
 
 ## Installation
 
-1. Clong this repo to your local machine:
+1. Clone this repo to your local machine:
 
 ```bash
 git clone https://github.com/microsoft/Magma


### PR DESCRIPTION
Readme Typo mistake .

In installation part 1 Clong this repo to your local machine:
change clong to clone .