### PR TITLE
chore: add gradio and history directories to .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,6 +61,12 @@ local_settings.py
 db.sqlite3
 db.sqlite3-journal
 
+# Gradio
+.gradio
+
+# History
+.history
+
 # Flask stuff:
 instance/
 .webassets-cache


### PR DESCRIPTION
## Changes
Added the following entries to .gitignore:
- `.gradio` directory - temporary gradio files
- `.history` directory - editor history files that are specific to local development

## Why
These dirs contain temporary files that shouldn't be tracked in version control. This helps keep the repo clean and prevents unnecessary files from being committed

## Testing
Verified that files in these directories are now properly ignored by git