### PR TITLE
fix: typo, remove unused and duplicate imports

### DIFF
--- a/magma/image_processing_magma.py
+++ b/magma/image_processing_magma.py
@@ -18,7 +18,6 @@
 from typing import List, Optional, Union
 import ast
 import numpy as np
-import torchvision
 from transformers.image_processing_utils import BaseImageProcessor, BatchFeature
 from transformers.image_transforms import (
     convert_to_rgb,
@@ -161,8 +160,8 @@ class MagmaImageProcessor(BaseImageProcessor):
 
     Args:
         anyres_strategy (`str`):
-            strategy to cope with high-resolution images. one conventional way is multi-crop and many other works to accomadate clip-vit models. 
-            however, since we are using convnext, which is essentially convnet, so we can use arbitary resolution images. as such, we use global strategy by defualt,
+            strategy to cope with high-resolution images. one conventional way is multi-crop and many other works to accommodate clip-vit models. 
+            however, since we are using convnext, which is essentially convnet, so we can use arbitary resolution images. as such, we use global strategy by default,
             i.e., directly resize image holistically to a certain resolution.
         base_img_size (int, *optional*, defaults to 768):
             as convnext has 1/32 downsample rate, we use 768 as the base resolution so that the resulted feature map is 24x24.

--- a/magma/image_tower_magma.py
+++ b/magma/image_tower_magma.py
@@ -21,8 +21,6 @@ import logging
 # Configure root logger
 logging.basicConfig(level=logging.INFO)
 
-import numpy as np
-import torchvision
 from transformers.image_processing_utils import BaseImageProcessor, BatchFeature
 from transformers.image_transforms import (
     convert_to_rgb,

--- a/magma/modeling_magma.py
+++ b/magma/modeling_magma.py
@@ -397,7 +397,7 @@ class MagmaForCausalLM(MagmaPreTrainedModel):
                 Indices of positions of each input sequence tokens in the position embeddings. Selected in the range `[0,
                 config.n_positions - 1]`.
             labels (`torch.Tensor` of shape `(batch_size, sequence_length)`, *optional*)
-                :abels need to be recalculated to support training (if provided)
+                :labels need to be recalculated to support training (if provided)
             image_token_index (`int`, *optional*)
                 Token id used to indicate the special "image" token. Defaults to `config.image_token_index`
             ignore_index (`int`, *optional*)

--- a/magma/processing_magma.py
+++ b/magma/processing_magma.py
@@ -18,7 +18,6 @@ Processor class for Magma.
 
 from typing import List, Optional, Union
 
-import transformers
 from transformers.feature_extraction_utils import BatchFeature
 from transformers.image_utils import ImageInput
 from transformers.processing_utils import ProcessorMixin
@@ -63,8 +62,8 @@ class MagmaProcessor(ProcessorMixin):
         """
         Main method to prepare for the model one or several sequences(s) and image(s). This method forwards the `text`
         and `kwargs` arguments to LlamaTokenizerFast's [`~LlamaTokenizerFast.__call__`] if `text` is not `None` to encode
-        the text. To prepare the image(s), this method forwards the `images` and `kwrags` arguments to
-        MagmaImageProcessor's [`~MagmaImageProcessor.__call__`] if `images` is not `None`. Please refer to the doctsring
+        the text. To prepare the image(s), this method forwards the `images` and `kwargs` arguments to
+        MagmaImageProcessor's [`~MagmaImageProcessor.__call__`] if `images` is not `None`. Please refer to the docstring
         of the above two methods for more information.
 
         Args:


### PR DESCRIPTION
Fixed typos and removed unused imports
* `magma/image_processing_magma.py` : **removed duplicate torchvision import**
* `magma/image_tower_magma.py` : **removed unused import numpy and duplicate torchvision**
* `magma/modeling_magma.py` : **fixed typo :abels -> :labels**
* `magma/processing_magma.py` : **removed unused import transformers and typo doctsring -> docstring**